### PR TITLE
[Feat] Session API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,9 @@ dependencies {
     // MongoDB
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
-
+    // WebClient (Spring Reactive Web)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/skala/nav7/api/profile/entity/Profile.java
+++ b/src/main/java/com/skala/nav7/api/profile/entity/Profile.java
@@ -39,4 +39,6 @@ public class Profile extends SoftDeletableEntity {
     Integer careerYear;
     @Column(name = "profile_img")
     String profileImage;
+    @Column(name = "career_title")
+    String careerTitle;
 }

--- a/src/main/java/com/skala/nav7/api/session/controller/SessionController.java
+++ b/src/main/java/com/skala/nav7/api/session/controller/SessionController.java
@@ -1,0 +1,104 @@
+package com.skala.nav7.api.session.controller;
+
+import com.skala.nav7.api.session.converter.SessionConverter;
+import com.skala.nav7.api.session.dto.request.SessionMessageRequestDTO;
+import com.skala.nav7.api.session.dto.request.SessionRequestDTO;
+import com.skala.nav7.api.session.dto.response.SessionMessageResponseDTO;
+import com.skala.nav7.api.session.dto.response.SessionResponseDTO;
+import com.skala.nav7.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sessions")
+@Tag(name = "Session 관련 API", description = "Session, Session Message 관련 API 입니다.")
+public class SessionController {
+
+    @Operation(
+            summary = "Session 생성",
+            description = "새로운 세션, 즉 첫 메세지를 보낼 때 사용하는 API 입니다."
+    )
+    @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<SessionResponseDTO.newSessionDTO> createNewSession(
+            @RequestBody SessionRequestDTO.newSessionDTO request
+    ) {
+        return ApiResponse.onSuccess(SessionConverter.to(UUID.randomUUID(), "안녕하세요 반갑습니다^^"));
+    }
+
+    @Operation(
+            summary = "Session 목록 조회",
+            description = "회원의 Session History 전체 목록을 조회합니다."
+    )
+    @GetMapping(value = "")
+    public ApiResponse<SessionResponseDTO.newSessionDTO> getSessionHistories(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime cursorAt,
+            @RequestParam(required = false)
+            UUID cursorId,
+            @RequestParam(defaultValue = "10")
+            int size
+    ) {
+//        if (cursorAt == null || cursorId == null) {
+//            // 첫 요청 → 최신순 정렬
+//            return sessionRepository.findTopNByMemberOrderByLastActiveAtDescIdDesc(memberId, size);
+//        } else {
+//            // 커서 기반 페이징
+//            return sessionRepository.findByCursor(memberId, cursorAt, cursorId, size);
+//        }
+        return ApiResponse.onSuccess(SessionConverter.to(UUID.randomUUID(), "안녕하세요 반갑습니다^^"));
+    }
+
+    @Operation(
+            summary = "새로운 Session 메세지 생성",
+            description = "세션에 관한 메세지를 보낼 때 사용하는 API 입니다."
+    )
+    @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<SessionMessageResponseDTO.newMessageDTO> createNewSession(
+            @RequestBody SessionMessageRequestDTO.newMessageDTO request
+    ) {
+        return ApiResponse.onSuccess(SessionConverter.toMessage(UUID.randomUUID(), "안녕하세요 반갑습니다^^"));
+    }
+
+    @Operation(
+            summary = "Session 상세 조회",
+            description = "Session History 상세 대화 내용을 커서 기반 페이지네이션으로 조회합니다."
+    )
+    @GetMapping("/{sessionId}")
+    public ApiResponse<?> getDetailSession(
+            @Parameter(description = "세션 UUID") @PathVariable UUID sessionId,
+            @Parameter(description = "마지막 메시지의 Mongo ObjectId (nextMessageId)")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "한 번에 가져올 메시지 수")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.onSuccess("");
+    }
+
+    @Operation(
+            summary = "Session 삭제",
+            description = "아이디에 해당하는 세션을 삭제합니다."
+    )
+    @PostMapping(value = "/delete/{sessionId}")
+    public ApiResponse<?> deleteSession(
+            @Parameter(description = "삭제할 세션의 UUID") @PathVariable Long sessionId
+    ) {
+        return ApiResponse.onSuccess("삭제가 완료되었습니다.");
+    }
+
+
+}

--- a/src/main/java/com/skala/nav7/api/session/converter/SessionConverter.java
+++ b/src/main/java/com/skala/nav7/api/session/converter/SessionConverter.java
@@ -4,6 +4,7 @@ import com.skala.nav7.api.session.dto.response.SessionMessageResponseDTO;
 import com.skala.nav7.api.session.dto.response.SessionResponseDTO;
 import com.skala.nav7.api.session.entity.Session;
 import com.skala.nav7.api.session.entity.SessionMessage;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
@@ -24,19 +25,41 @@ public class SessionConverter {
     }
 
     public static SessionMessageResponseDTO.SessionDetailDTO to(Session session,
-                                                                Slice<SessionMessage> sessionMessageSlice) {
-        List<SessionMessage> content = sessionMessageSlice.getContent();
-        SessionMessage lastMessage = content.isEmpty() ? null : content.get(content.size() - 1);
-
-        String nextMessageId = sessionMessageSlice.hasNext() && lastMessage != null ? lastMessage.getId() : null;
+                                                                List<SessionMessage> messages, int size) {
+        boolean hasNext = messages.size() > size;
+        List<SessionMessage> contents = hasNext ? messages.subList(0, size) : messages;
+        SessionMessage last = contents.isEmpty() ? null : contents.get(contents.size() - 1);
+        String nextMessageId = hasNext && last != null ? last.getId() : null;
         return SessionMessageResponseDTO.SessionDetailDTO.builder()
                 .sessionTitle(session.getSessionTitle())
-                .lastActiveAt(session.getLastActiveAt())
                 .createdAt(session.getCreatedAt())
                 .sessionId(session.getId())
-                .hasNext(sessionMessageSlice.hasNext())
+                .hasNext(hasNext)
                 .nextMessageId(nextMessageId)
-                .messages(content.stream().map(SessionConverter::to).toList())
+                .messages(contents.stream().map(SessionConverter::to).toList())
+                .build();
+    }
+
+    public static SessionResponseDTO.SessionDetailDTO to(Session session) {
+        return SessionResponseDTO.SessionDetailDTO.builder()
+                .sessionId(session.getId())
+                .sessionTitle(session.getSessionTitle())
+                .createdAt(session.getCreatedAt())
+                .build();
+    }
+
+    public static SessionResponseDTO.SessionListDTO to(Slice<Session> sessionSlice) {
+        List<Session> content = sessionSlice.getContent();
+        Session lastSession = content.isEmpty() ? null : content.get(content.size() - 1);
+
+        UUID nextMessageId = sessionSlice.hasNext() && lastSession != null ? lastSession.getId() : null;
+        LocalDateTime nextCreatedAt = sessionSlice.hasNext() && lastSession != null ? lastSession.getCreatedAt() : null;
+
+        return SessionResponseDTO.SessionListDTO.builder()
+                .hasNext(sessionSlice.hasNext())
+                .nextMessageId(nextMessageId)
+                .nextCreatedAt(nextCreatedAt)
+                .details(content.stream().map(SessionConverter::to).toList())
                 .build();
     }
 

--- a/src/main/java/com/skala/nav7/api/session/converter/SessionConverter.java
+++ b/src/main/java/com/skala/nav7/api/session/converter/SessionConverter.java
@@ -1,0 +1,50 @@
+package com.skala.nav7.api.session.converter;
+
+import com.skala.nav7.api.session.dto.response.SessionMessageResponseDTO;
+import com.skala.nav7.api.session.dto.response.SessionResponseDTO;
+import com.skala.nav7.api.session.entity.Session;
+import com.skala.nav7.api.session.entity.SessionMessage;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Slice;
+
+public class SessionConverter {
+    public static SessionResponseDTO.newSessionDTO to(UUID sessionId, String answer) {
+        return SessionResponseDTO.newSessionDTO.builder()
+                .answer(answer)
+                .sessionId(sessionId)
+                .build();
+    }
+
+    public static SessionMessageResponseDTO.newMessageDTO toMessage(UUID sessionId, String answer) {
+        return SessionMessageResponseDTO.newMessageDTO.builder()
+                .answer(answer)
+                .sessionId(sessionId)
+                .build();
+    }
+
+    public static SessionMessageResponseDTO.SessionDetailDTO to(Session session,
+                                                                Slice<SessionMessage> sessionMessageSlice) {
+        List<SessionMessage> content = sessionMessageSlice.getContent();
+        SessionMessage lastMessage = content.isEmpty() ? null : content.get(content.size() - 1);
+
+        String nextMessageId = sessionMessageSlice.hasNext() && lastMessage != null ? lastMessage.getId() : null;
+        return SessionMessageResponseDTO.SessionDetailDTO.builder()
+                .sessionTitle(session.getSessionTitle())
+                .lastActiveAt(session.getLastActiveAt())
+                .createdAt(session.getCreatedAt())
+                .sessionId(session.getId())
+                .hasNext(sessionMessageSlice.hasNext())
+                .nextMessageId(nextMessageId)
+                .messages(content.stream().map(SessionConverter::to).toList())
+                .build();
+    }
+
+    public static SessionMessageResponseDTO.SessionMessageDTO to(SessionMessage sessionMessage) {
+        return SessionMessageResponseDTO.SessionMessageDTO.builder()
+                .answer(sessionMessage.getAnswer())
+                .question(sessionMessage.getQuestion())
+                .createdAt(sessionMessage.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/dto/request/SessionMessageRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/request/SessionMessageRequestDTO.java
@@ -1,0 +1,12 @@
+package com.skala.nav7.api.session.dto.request;
+
+import java.util.UUID;
+
+public record SessionMessageRequestDTO(
+) {
+    public record newMessageDTO(
+            UUID sessionId,
+            String question //sessionTitle
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/dto/request/SessionMessageRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/request/SessionMessageRequestDTO.java
@@ -1,11 +1,8 @@
 package com.skala.nav7.api.session.dto.request;
 
-import java.util.UUID;
-
 public record SessionMessageRequestDTO(
 ) {
     public record newMessageDTO(
-            UUID sessionId,
             String question //sessionTitle
     ) {
     }

--- a/src/main/java/com/skala/nav7/api/session/dto/request/SessionRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/request/SessionRequestDTO.java
@@ -1,0 +1,13 @@
+package com.skala.nav7.api.session.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SessionRequestDTO(
+) {
+    @Schema(description = "세션 생성 요청 DTO")
+    public record newSessionDTO(
+            @Schema(description = "사용자의 질문", example = "오늘 뭐 먹지?")
+            String question
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/dto/response/SessionMessageResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/response/SessionMessageResponseDTO.java
@@ -1,0 +1,53 @@
+package com.skala.nav7.api.session.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+
+public record SessionMessageResponseDTO(
+) {
+    @Builder
+    public record newMessageDTO(
+            UUID sessionId,
+            String answer
+    ) {
+    }
+
+    @Schema(description = "세션 상세 및 메시지 목록")
+    @Builder
+    public record SessionDetailDTO(
+            @Schema(description = "세션 ID", example = "3f29bde0-8b79-4f50-a6a2-7e0d3e913437")
+            UUID sessionId,
+            @Schema(description = "세션 제목", example = "커리어 상담")
+            String sessionTitle,
+            @Schema(description = "세션 생성 시각", example = "2025-05-28T10:00:00")
+            LocalDateTime createdAt,
+            @Schema(description = "세션 마지막 활동 시각", example = "2025-05-28T11:00:00")
+            LocalDateTime lastActiveAt,
+            @Schema(description = "조회된 메시지 목록")
+            List<SessionMessageDTO> messages,
+            @Schema(description = "다음 페이지 존재 여부", example = "true")
+            boolean hasNext,
+            @Schema(description = "다음 페이지 조회용 커서 (문자열 ID)", example = "66558f13c7f9cfa8a98de3f2")
+            String nextMessageId
+
+    ) {
+    }
+
+    @Schema(description = "세션 메시지 정보")
+    @Builder
+    public record SessionMessageDTO(
+            @Schema(description = "메시지 작성 시각")
+            LocalDateTime createdAt,
+
+            @Schema(description = "질문 내용")
+            String question,
+
+            @Schema(description = "AI 답변 내용")
+            String answer
+    ) {
+    }
+
+}

--- a/src/main/java/com/skala/nav7/api/session/dto/response/SessionResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/response/SessionResponseDTO.java
@@ -1,0 +1,42 @@
+package com.skala.nav7.api.session.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+
+public record SessionResponseDTO(
+) {
+    @Builder
+    @Schema(description = "세션 생성 응답 DTO")
+    public record newSessionDTO(
+            @Schema(description = "세션 ID", example = "123")
+            UUID sessionId,
+
+            @Schema(description = "AI 응답", example = "안녕하세요, 어떤 도움이 필요하신가요?")
+            String answer
+    ) {
+    }
+
+    @Schema(description = "세션 상세 및 메시지 목록")
+    @Builder
+    public record SessionListDTO(
+            @Schema(description = "세션 ID", example = "3f29bde0-8b79-4f50-a6a2-7e0d3e913437")
+            UUID sessionId,
+            @Schema(description = "세션 제목", example = "커리어 상담")
+            String sessionTitle,
+            @Schema(description = "세션 생성 시각", example = "2025-05-28T10:00:00")
+            LocalDateTime createdAt,
+            @Schema(description = "세션 마지막 활동 시각", example = "2025-05-28T11:00:00")
+            LocalDateTime lastActiveAt,
+            @Schema(description = "조회된 메시지 목록")
+            List<SessionMessageResponseDTO.SessionMessageDTO> messages,
+            @Schema(description = "다음 페이지 존재 여부", example = "true")
+            boolean hasNext,
+            @Schema(description = "다음 페이지 조회용 커서 (문자열 ID)", example = "66558f13c7f9cfa8a98de3f2")
+            String nextMessageId
+
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/dto/response/SessionResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/response/SessionResponseDTO.java
@@ -19,23 +19,30 @@ public record SessionResponseDTO(
     ) {
     }
 
-    @Schema(description = "세션 상세 및 메시지 목록")
+    @Schema(description = "세션 무한 커서 DTO")
     @Builder
     public record SessionListDTO(
+            @Schema(description = "조회된 메시지 목록")
+            List<SessionResponseDTO.SessionDetailDTO> details,
+            @Schema(description = "다음 페이지 존재 여부", example = "true")
+            boolean hasNext,
+            @Schema(description = "다음 페이지 조회용 시각", example = "2025-05-28T10:00:00")
+            LocalDateTime nextCreatedAt,
+            @Schema(description = "다음 페이지 조회용 커서 (문자열 ID)", example = "66558f13c7f9cfa8a98de3f2")
+            UUID nextMessageId
+
+    ) {
+    }
+
+    @Schema(description = "세션 목록")
+    @Builder
+    public record SessionDetailDTO(
             @Schema(description = "세션 ID", example = "3f29bde0-8b79-4f50-a6a2-7e0d3e913437")
             UUID sessionId,
             @Schema(description = "세션 제목", example = "커리어 상담")
             String sessionTitle,
             @Schema(description = "세션 생성 시각", example = "2025-05-28T10:00:00")
-            LocalDateTime createdAt,
-            @Schema(description = "세션 마지막 활동 시각", example = "2025-05-28T11:00:00")
-            LocalDateTime lastActiveAt,
-            @Schema(description = "조회된 메시지 목록")
-            List<SessionMessageResponseDTO.SessionMessageDTO> messages,
-            @Schema(description = "다음 페이지 존재 여부", example = "true")
-            boolean hasNext,
-            @Schema(description = "다음 페이지 조회용 커서 (문자열 ID)", example = "66558f13c7f9cfa8a98de3f2")
-            String nextMessageId
+            LocalDateTime createdAt
 
     ) {
     }

--- a/src/main/java/com/skala/nav7/api/session/entity/Session.java
+++ b/src/main/java/com/skala/nav7/api/session/entity/Session.java
@@ -1,6 +1,7 @@
 package com.skala.nav7.api.session.entity;
 
 import com.skala.nav7.api.member.entity.Member;
+import com.skala.nav7.global.base.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,8 +26,7 @@ import lombok.experimental.FieldDefaults;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "session")
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class Session {
-
+public class Session extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "session_id", nullable = false)
@@ -36,13 +35,6 @@ public class Session {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     Member member;
-
-    @Column(name = "created_at", nullable = false)
-    LocalDateTime createdAt;
-
-    @Column(name = "last_active_at", nullable = false)
-    LocalDateTime lastActiveAt;
-
     @Column(name = "session_title", nullable = false)
     String sessionTitle;
 }

--- a/src/main/java/com/skala/nav7/api/session/entity/SessionMessage.java
+++ b/src/main/java/com/skala/nav7/api/session/entity/SessionMessage.java
@@ -7,14 +7,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.FieldDefaults;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "session_messages")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -25,7 +23,6 @@ public class SessionMessage {
     String id;
     String sessionId;     // PostgreSQL의 UUID 기반 세션 ID
     LocalDateTime createdAt;
-    LocalDateTime lastActiveAt;
     String question;
     String answer;
 }

--- a/src/main/java/com/skala/nav7/api/session/exception/FastAPIErrorCode.java
+++ b/src/main/java/com/skala/nav7/api/session/exception/FastAPIErrorCode.java
@@ -1,0 +1,27 @@
+package com.skala.nav7.api.session.exception;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.apiPayload.dto.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FastAPIErrorCode implements BaseErrorCode {
+    FAST_API_ERROR(HttpStatus.BAD_REQUEST, "FAST_API_500", "AI Agent 응답 생성 중 오류가 발생했습니다."),
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .httpStatus(this.status)
+                .isSuccess(false) // 에러이므로 항상 false
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/exception/FastAPIException.java
+++ b/src/main/java/com/skala/nav7/api/session/exception/FastAPIException.java
@@ -1,0 +1,10 @@
+package com.skala.nav7.api.session.exception;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.exception.GeneralException;
+
+public class FastAPIException extends GeneralException {
+    public FastAPIException(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/exception/SessionErrorCode.java
+++ b/src/main/java/com/skala/nav7/api/session/exception/SessionErrorCode.java
@@ -1,0 +1,28 @@
+package com.skala.nav7.api.session.exception;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.apiPayload.dto.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SessionErrorCode implements BaseErrorCode {
+    NOT_HAVE_AUTHORIZATION(HttpStatus.NOT_FOUND, "SESSION_401", "해당 세션에 대한 권한이 존재하지 않습니다."),
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_404", "해당 세션이 존재하지 않습니다."),
+    SESSION_ERROR(HttpStatus.BAD_REQUEST, "SESSION_500", "Session 관련 오류가 발생했습니다.");
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .httpStatus(this.status)
+                .isSuccess(false) // 에러이므로 항상 false
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/exception/SessionException.java
+++ b/src/main/java/com/skala/nav7/api/session/exception/SessionException.java
@@ -1,0 +1,10 @@
+package com.skala.nav7.api.session.exception;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.exception.GeneralException;
+
+public class SessionException extends GeneralException {
+    public SessionException(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/exception/SessionSuccessCode.java
+++ b/src/main/java/com/skala/nav7/api/session/exception/SessionSuccessCode.java
@@ -1,0 +1,30 @@
+package com.skala.nav7.api.session.exception;
+
+
+import com.skala.nav7.global.apiPayload.code.base.BaseCode;
+import com.skala.nav7.global.apiPayload.dto.ReasonDTO;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum SessionSuccessCode implements BaseCode {
+    SESSION_OK(HttpStatus.OK, "COMMON200", "성공했습니다."),
+    SESSION_CREATED(HttpStatus.CREATED, "COMMON201", "새로운 세션을 생성했습니다."),
+    SESSION_NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON204", "삭제했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .httpStatus(this.httpStatus)
+                .isSuccess(true)
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/repository/SessionRepository.java
+++ b/src/main/java/com/skala/nav7/api/session/repository/SessionRepository.java
@@ -1,10 +1,32 @@
 package com.skala.nav7.api.session.repository;
 
 
+import com.skala.nav7.api.member.entity.Member;
 import com.skala.nav7.api.session.entity.Session;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SessionRepository extends JpaRepository<Session, Long> {
+public interface SessionRepository extends JpaRepository<Session, UUID> {
+
+    Slice<Session> findTopNByMemberOrderByCreatedAtDescIdDesc(Member member, Pageable pageable);
+
+    @Query("""
+                SELECT s FROM Session s
+                WHERE s.member = :member
+                  AND (s.createdAt < :cursorAt OR (s.createdAt = :cursorAt AND s.id < :cursorId))
+                ORDER BY s.createdAt DESC, s.id DESC
+            """)
+    Slice<Session> findByCursor(
+            @Param("member") Member member,
+            @Param("cursorAt") LocalDateTime cursorAt,
+            @Param("cursorId") UUID cursorId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/skala/nav7/api/session/service/FastApiClientService.java
+++ b/src/main/java/com/skala/nav7/api/session/service/FastApiClientService.java
@@ -1,0 +1,55 @@
+package com.skala.nav7.api.session.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.skala.nav7.api.session.exception.FastAPIErrorCode;
+import com.skala.nav7.api.session.exception.FastAPIException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FastApiClientService {
+    private final WebClient fastApiWebClient;
+    private final static String GENERAL_CHAT_URL = "/career-path";
+
+    public String askCareerPath(String question) {
+        try {
+            return fastApiWebClient.post()
+                    .uri(GENERAL_CHAT_URL)
+                    .bodyValue(Map.of("question", question))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, this::handleError)
+                    .bodyToMono(String.class)
+                    .doOnError(e -> log.error("FAST API ERROR: {} ", e.getMessage()))
+                    .block();
+        } catch (Exception e) {
+            throw new FastAPIException(FastAPIErrorCode.FAST_API_ERROR);
+        }
+    }
+
+
+    private Mono<? extends Throwable> handleError(ClientResponse response) {
+        return response.bodyToMono(String.class)
+                .flatMap(errorBody -> {
+                    log.error("FastAPI 응답 오류 바디: {}", errorBody);
+                    try {
+                        ObjectMapper objectMapper = new ObjectMapper();
+                        JsonNode root = objectMapper.readTree(errorBody);
+                        String errorCode = root.path("error_code").asText();
+                        return Mono.error(new RuntimeException("FastAPI 오류 코드: " + errorCode));
+                    } catch (Exception e) {
+                        log.error("FastAPI 에러 바디 파싱 실패: {}", e.getMessage());
+                        return Mono.error(new RuntimeException("FastAPI 응답 파싱 실패: " + errorBody));
+                    }
+                });
+    }
+
+}

--- a/src/main/java/com/skala/nav7/api/session/service/SessionService.java
+++ b/src/main/java/com/skala/nav7/api/session/service/SessionService.java
@@ -1,0 +1,104 @@
+package com.skala.nav7.api.session.service;
+
+import com.skala.nav7.api.member.entity.Member;
+import com.skala.nav7.api.session.converter.SessionConverter;
+import com.skala.nav7.api.session.dto.request.SessionMessageRequestDTO;
+import com.skala.nav7.api.session.dto.request.SessionRequestDTO;
+import com.skala.nav7.api.session.dto.response.SessionMessageResponseDTO;
+import com.skala.nav7.api.session.dto.response.SessionResponseDTO;
+import com.skala.nav7.api.session.entity.Session;
+import com.skala.nav7.api.session.entity.SessionMessage;
+import com.skala.nav7.api.session.exception.SessionErrorCode;
+import com.skala.nav7.api.session.exception.SessionException;
+import com.skala.nav7.api.session.repository.SessionMessageRepository;
+import com.skala.nav7.api.session.repository.SessionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+    private final SessionRepository sessionRepository;
+    private final SessionMessageRepository sessionMessageRepository;
+    private final FastApiClientService fastApiClientService;
+    private final MongoTemplate mongoTemplate;
+
+    public SessionResponseDTO.newSessionDTO createNewSessions(Member member, SessionRequestDTO.newSessionDTO dto) {
+        Session session = Session.builder().member(member).sessionTitle(dto.question()).build();
+        String answer = fastApiClientService.askCareerPath(dto.question());
+        sessionRepository.save(session);
+        SessionMessage message = SessionMessage.builder().sessionId(session.getId().toString())
+                .createdAt(LocalDateTime.now())
+                .createdAt(session.getCreatedAt())
+                .answer(answer).question(
+                        dto.question()).build();
+        sessionMessageRepository.save(message);
+        return SessionConverter.to(session.getId(), answer);
+    }
+
+    public Slice<Session> getSessionList(Member member, LocalDateTime cursorAt, UUID cursorId, int size) {
+        if (cursorAt == null || cursorId == null) { // 첫 요청
+            return sessionRepository.findTopNByMemberOrderByCreatedAtDescIdDesc(member, PageRequest.of(0, size));
+        } else { // 커서 기반 페이징
+            return sessionRepository.findByCursor(member, cursorAt, cursorId,
+                    PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt", "id")));
+        }
+    }
+
+    public SessionMessageResponseDTO.newMessageDTO createNewMessage(Member member, UUID sessionId,
+                                                                    SessionMessageRequestDTO.newMessageDTO dto) {
+        Session session = getSession(sessionId);
+        String answer = fastApiClientService.askCareerPath(dto.question());
+        SessionMessage message = SessionMessage.builder().sessionId(String.valueOf(session.getId()))
+                .createdAt(session.getCreatedAt())
+                .answer(answer).question(
+                        dto.question()).build();
+        sessionMessageRepository.save(message);
+        return SessionConverter.toMessage(session.getId(), answer);
+    }
+
+    public SessionMessageResponseDTO.SessionDetailDTO getSessionMessageList(Member member, UUID sessionId,
+                                                                            String cursor, int size) {
+        Session session = getSession(sessionId);
+        Query query = new Query();
+        query.addCriteria(Criteria.where("sessionId").is(sessionId.toString())); //해당 SessionId만 가져옴
+        //커서이후의 데이터만 필터링한다
+        if (cursor != null && !cursor.isEmpty()) {
+            query.addCriteria(Criteria.where("_id").gt(new ObjectId(cursor)));
+        }
+        query.with(Sort.by(Sort.Direction.ASC, "_id")); //_id 오름차순 필터링
+        query.limit(size + 1); //조회 갯수 제한
+        List<SessionMessage> messages = mongoTemplate.find(query, SessionMessage.class);
+
+        return SessionConverter.to(session, messages, size);
+    }
+
+    public void deleteSession(Member member, UUID sessionId) {
+        Session session = getSession(sessionId);
+        if (!session.getMember().equals(member)) {
+            throw new SessionException(SessionErrorCode.NOT_HAVE_AUTHORIZATION);
+        }
+        sessionRepository.delete(session);
+
+        Query query = new Query();
+        query.addCriteria(Criteria.where("sessionId").is(sessionId.toString())); // 특정 세션의 메시지 전부
+        mongoTemplate.remove(query, SessionMessage.class);
+    }
+
+    private Session getSession(UUID sessionId) {
+        return sessionRepository.findById(sessionId).orElseThrow(
+                () -> new SessionException(SessionErrorCode.SESSION_NOT_FOUND)
+        );
+    }
+
+}

--- a/src/main/java/com/skala/nav7/global/base/DummyMemberInitializer.java
+++ b/src/main/java/com/skala/nav7/global/base/DummyMemberInitializer.java
@@ -1,0 +1,91 @@
+package com.skala.nav7.global.base;
+
+import com.skala.nav7.api.member.entity.Gender;
+import com.skala.nav7.api.member.entity.Member;
+import com.skala.nav7.api.member.repository.MemberRepository;
+import com.skala.nav7.api.session.entity.Session;
+import com.skala.nav7.api.session.entity.SessionMessage;
+import com.skala.nav7.api.session.repository.SessionRepository;
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DummyMemberInitializer {
+    private final MongoTemplate mongoTemplate;
+    private final MemberRepository memberRepository;
+    private final SessionRepository sessionRepository;
+    private Member dummyMember;
+
+    @PostConstruct
+    public void init() {
+        if (memberRepository.findById(1L).isEmpty()) {
+            Member dummy = Member.builder()
+                    .id(1L)
+                    .email("ccyy8432@naver.com")
+                    .gender(Gender.FEMALE)
+                    .loginId("testId")
+                    .password("test1234")
+                    .memberName("김더미")
+                    .build();
+            memberRepository.save(dummy);
+            dummyMember = dummy;
+            initSession();
+        } else {
+            dummyMember = memberRepository.findById(1L).get();
+        }
+    }
+
+    private void initSession() {
+
+        Session session = Session.builder()
+                .sessionTitle("커리어 Path 추천").member(dummyMember).build();
+        sessionRepository.save(session);
+
+        String sessionId = session.getId().toString();
+
+        List<SessionMessage> messages = List.of(
+                SessionMessage.builder()
+                        .sessionId(sessionId)
+                        .createdAt(LocalDateTime.now())
+                        .question("프론트엔드인데, 앞이 막막해... 앞으로의 Path 추천해줘")
+                        .answer("클라우드와 백엔드 시스템 이해를 위해 강의를 들어보세요.")
+                        .build(),
+                SessionMessage.builder()
+                        .sessionId(sessionId)
+                        .createdAt(LocalDateTime.now().plusSeconds(5))
+                        .question("React를 공부하고 있는데 그 다음은?")
+                        .answer("상태관리 도구와 TypeScript를 학습해보는 걸 추천해요.")
+                        .build(),
+                SessionMessage.builder()
+                        .sessionId(sessionId)
+                        .createdAt(LocalDateTime.now().plusSeconds(10))
+                        .question("프로젝트를 뭘 해야 할까요?")
+                        .answer("팀 프로젝트로 포트폴리오를 만들어보세요. 예: Todo앱, 블로그 등")
+                        .build(),
+                SessionMessage.builder()
+                        .sessionId(sessionId)
+                        .createdAt(LocalDateTime.now().plusSeconds(15))
+                        .question("CS 지식은 얼마나 알아야 해요?")
+                        .answer("네트워크, 운영체제, DB 기본 정도는 알고 있으면 좋아요.")
+                        .build(),
+                SessionMessage.builder()
+                        .sessionId(sessionId)
+                        .createdAt(LocalDateTime.now().plusSeconds(20))
+                        .question("이력서를 어떻게 써야 하나요?")
+                        .answer("구체적인 프로젝트 경험과 역할, 성과를 중심으로 작성해보세요.")
+                        .build()
+        );
+
+        mongoTemplate.insertAll(messages);
+
+    }
+
+    public Member getDummyMember() {
+        return dummyMember;
+    }
+}

--- a/src/main/java/com/skala/nav7/global/config/WebClientConfig.java
+++ b/src/main/java/com/skala/nav7/global/config/WebClientConfig.java
@@ -1,0 +1,20 @@
+package com.skala.nav7.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    private static String FAST_API_URL = "https://sk-nav7.skala25a.project.skala-ai.com/apis/v1/";
+
+    @Bean
+    public WebClient fastApiWebClient() {
+        return WebClient.builder()
+                .baseUrl(FAST_API_URL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/test/java/com/skala/nav7/api/session/service/FastApiClientServiceTest.java
+++ b/src/test/java/com/skala/nav7/api/session/service/FastApiClientServiceTest.java
@@ -1,0 +1,28 @@
+package com.skala.nav7.api.session.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class FastApiClientServiceTest {
+    private FastApiClientService service;
+    private static String FAST_API_URL = "https://sk-nav7.skala25a.project.skala-ai.com/apis/v1/";
+
+    @BeforeEach
+    void setUp() {
+        WebClient client = WebClient.builder()
+                .baseUrl(FAST_API_URL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        service = new FastApiClientService(client);
+    }
+
+    @Test
+    void askCareerPath() {
+        String answer = service.askCareerPath("Cloud 천재가 되기 위해선 어떻게 해?");
+        Assertions.assertEquals("\"커리어추천: cloud 강의 듣기\"", answer);
+    }
+}


### PR DESCRIPTION
## 🔥 작업 개요
- 세션 상세 조회 기능 구현 (MongoDB 기반 커서 페이징 적용)
- 신규 세션 생성 시 FastAPI 응답을 기반으로 Session + SessionMessage 저장 로직 구현

## ✅ 관련 이슈
- close #11

## ✨ 주요 변경사항
- GET /sessions/{sessionId}: 세션 메시지 목록을 커서 기반 페이징으로 조회하는 API 구현
- _id 기준으로 ObjectId 커서를 이용한 MongoDB 커서 페이징 로직 작성
- nextMessageId로 다음 페이지 커서 제공
- POST /sessions: 새로운 세션 생성 및 FastAPI를 통한 초기 응답 저장 기능 구현
- Session 엔티티 저장 후, 해당 UUID를 기반으로 SessionMessage 저장
- FastAPI 클라이언트로부터 받은 답변(answer) 저장 처리
- SessionConverter, SessionService, DTO, Controller 로직 정리 및 리팩토링
- SessionMessage Mongo 문서에 대한 더미 데이터 테스트 작성


## 📸 스크린샷(선택)

## 🧪 테스트 (선택)
- [ ] 로컬에서 테스트 완료
- [ ] 테스트 코드 실행 (`./gradlew test`)

## 📝 ETC (선택)
- MongoDB 는 MongoRepository 에서  기본적으로 커서기반 페이징을 제공하지 않음 -> MongoTemplate 사용해서, _id인 ObjectId를 커서로 사용
- session은 날짜가 제공되지 않은 UUID이기 때문에 날짜 정보와 함께 커서로 사용
- 추후 Member 인증 로직이 추가 되면, DummyMemberInitializer 제거