### PR TITLE
[Refactor] Session 응답 FAST API 의 스키마로 변경

### DIFF
--- a/src/main/java/com/skala/nav7/api/session/controller/SessionController.java
+++ b/src/main/java/com/skala/nav7/api/session/controller/SessionController.java
@@ -17,7 +17,6 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,7 +36,7 @@ public class SessionController {
             summary = "Session 생성",
             description = "새로운 세션, 즉 첫 메세지를 보낼 때 사용하는 API 입니다."
     )
-    @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "")
     public ApiResponse<SessionResponseDTO.newSessionDTO> createNewSession(
             @MemberEntity Member member,
             @RequestBody SessionRequestDTO.newSessionDTO request
@@ -69,7 +68,7 @@ public class SessionController {
             summary = "새로운 Session 메세지 생성",
             description = "세션에 관한 메세지를 보낼 때 사용하는 API 입니다."
     )
-    @PostMapping(value = "/{sessionId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{sessionId}")
     public ApiResponse<SessionMessageResponseDTO.newMessageDTO> createNewSession(
             @MemberEntity Member member,
             @Parameter(description = "세션의 UUID") @PathVariable UUID sessionId,

--- a/src/main/java/com/skala/nav7/api/session/converter/SessionConverter.java
+++ b/src/main/java/com/skala/nav7/api/session/converter/SessionConverter.java
@@ -5,21 +5,22 @@ import com.skala.nav7.api.session.dto.response.SessionResponseDTO;
 import com.skala.nav7.api.session.entity.Session;
 import com.skala.nav7.api.session.entity.SessionMessage;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 
 public class SessionConverter {
-    public static SessionResponseDTO.newSessionDTO to(UUID sessionId, String answer) {
+    public static SessionResponseDTO.newSessionDTO to(UUID sessionId, HashMap<String, String> map) {
         return SessionResponseDTO.newSessionDTO.builder()
-                .answer(answer)
+                .map(map)
                 .sessionId(sessionId)
                 .build();
     }
 
-    public static SessionMessageResponseDTO.newMessageDTO toMessage(UUID sessionId, String answer) {
+    public static SessionMessageResponseDTO.newMessageDTO toMessage(UUID sessionId, HashMap<String, String> map) {
         return SessionMessageResponseDTO.newMessageDTO.builder()
-                .answer(answer)
+                .map(map)
                 .sessionId(sessionId)
                 .build();
     }

--- a/src/main/java/com/skala/nav7/api/session/dto/request/FastAPIRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/request/FastAPIRequestDTO.java
@@ -8,11 +8,14 @@ public record FastAPIRequestDTO(
             @Schema(description = "사용자 ID", example = "1")
             String user_id,
 
+            @Schema(description = "세션 ID", example = "ad32048a-3b55-4ddb-bee5-b9ffe1c06cee")
+            String session_id,
+
             @Schema(description = "사용자의 질문", example = "어떤 경로로 개발자가 될 수 있을까요?")
             String user_query
     ) {
-        public static CareerPathRequestDTO of(Long profileId, String question) {
-            return new CareerPathRequestDTO(String.valueOf(profileId), question);
+        public static CareerPathRequestDTO of(Long profileId, String sessionId, String question) {
+            return new CareerPathRequestDTO(String.valueOf(profileId), sessionId, question);
         }
     }
 }

--- a/src/main/java/com/skala/nav7/api/session/dto/request/FastAPIRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/request/FastAPIRequestDTO.java
@@ -1,0 +1,18 @@
+package com.skala.nav7.api.session.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record FastAPIRequestDTO(
+) {
+    public record CareerPathRequestDTO(
+            @Schema(description = "사용자 ID", example = "1")
+            String user_id,
+
+            @Schema(description = "사용자의 질문", example = "어떤 경로로 개발자가 될 수 있을까요?")
+            String user_query
+    ) {
+        public static CareerPathRequestDTO of(Long profileId, String question) {
+            return new CareerPathRequestDTO(String.valueOf(profileId), question);
+        }
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/dto/response/FastAPIResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/response/FastAPIResponseDTO.java
@@ -1,0 +1,36 @@
+package com.skala.nav7.api.session.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.HashMap;
+import lombok.Builder;
+
+
+public record FastAPIResponseDTO(
+) {
+    public record CareerResponseDTO(
+            @Schema(description = "응답 데이터")
+            Content content
+    ) {
+        @Builder
+        @Schema(description = "FastAPI 최상위 content 객체")
+        public record Content(
+                @Schema(description = "성공 여부", example = "true")
+                boolean success,
+
+                @Schema(description = "실제 결과")
+                CareerDTO result
+        ) {
+        }
+
+        @Builder
+        @Schema(description = "Career 관련 응답 DTO")
+        public record CareerDTO(
+                @Schema(description = "Agent 종류", example = "CareerSummary")
+                String agent,
+
+                @Schema(description = "AI 응답 맵", example = "{\"summary\":\"요약\", \"goal\":\"목표\"}")
+                HashMap<String, String> map
+        ) {
+        }
+    }
+}

--- a/src/main/java/com/skala/nav7/api/session/dto/response/FastAPIResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/response/FastAPIResponseDTO.java
@@ -1,36 +1,25 @@
 package com.skala.nav7.api.session.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.HashMap;
-import lombok.Builder;
-
+import com.fasterxml.jackson.databind.JsonNode;
 
 public record FastAPIResponseDTO(
+        Content content
 ) {
-    public record CareerResponseDTO(
-            @Schema(description = "응답 데이터")
-            Content content
+    public record Content(
+            boolean success,
+            Result result
     ) {
-        @Builder
-        @Schema(description = "FastAPI 최상위 content 객체")
-        public record Content(
-                @Schema(description = "성공 여부", example = "true")
-                boolean success,
+    }
 
-                @Schema(description = "실제 결과")
-                CareerDTO result
-        ) {
-        }
+    public record Result(
+            String agent,
+            JsonNode text
+    ) {
+    }
 
-        @Builder
-        @Schema(description = "Career 관련 응답 DTO")
-        public record CareerDTO(
-                @Schema(description = "Agent 종류", example = "CareerSummary")
-                String agent,
-
-                @Schema(description = "AI 응답 맵", example = "{\"summary\":\"요약\", \"goal\":\"목표\"}")
-                HashMap<String, String> map
-        ) {
-        }
+    public record RoleModelDTO(
+            Long profileId,
+            double similarity_score
+    ) {
     }
 }

--- a/src/main/java/com/skala/nav7/api/session/dto/response/SessionMessageResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/response/SessionMessageResponseDTO.java
@@ -2,6 +2,7 @@ package com.skala.nav7.api.session.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -10,8 +11,23 @@ public record SessionMessageResponseDTO(
 ) {
     @Builder
     public record newMessageDTO(
+            @Schema(description = "세션 ID", example = "123")
             UUID sessionId,
-            String answer
+            @Schema(
+                    description = """
+                            AI 응답 결과. 응답 타입에 따라 구조가 달라집니다.
+                                    
+                            - 일반 메시지: {"response": "안녕하세요, 어떤 진로가 고민이신가요?"}
+                            - RoleModel 에이전트: {"profileId_0": "10", "score_0": "0.85", "profileId_1": "12", "score_1": "0.73"}
+                            - 기타 구조 (fallback): {"raw": "{\\"someField\\":\\"value\\",\\"anotherField\\":123}"}
+                            """,
+                    example = """
+                            {
+                              "response": "안녕하세요, 어떤 진로가 고민이신가요?"
+                            }
+                            """
+            )
+            HashMap<String, String> map
     ) {
     }
 

--- a/src/main/java/com/skala/nav7/api/session/dto/response/SessionResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/session/dto/response/SessionResponseDTO.java
@@ -2,6 +2,7 @@ package com.skala.nav7.api.session.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -14,8 +15,22 @@ public record SessionResponseDTO(
             @Schema(description = "세션 ID", example = "123")
             UUID sessionId,
 
-            @Schema(description = "AI 응답", example = "안녕하세요, 어떤 도움이 필요하신가요?")
-            String answer
+            @Schema(
+                    description = """
+                            AI 응답 결과. 응답 타입에 따라 구조가 달라집니다.
+                                    
+                            - 일반 메시지: {"response": "안녕하세요, 어떤 진로가 고민이신가요?"}
+                            - RoleModel 에이전트: {"profileId_0": "10", "score_0": "0.85", "profileId_1": "12", "score_1": "0.73"}
+                            - 기타 구조 (fallback): {"raw": "{\\"someField\\":\\"value\\",\\"anotherField\\":123}"}
+                            """,
+                    type = "object",
+                    example = """
+                            {
+                              "response": "안녕하세요, 어떤 진로가 고민이신가요?"
+                            }
+                            """
+            )
+            HashMap<String, String> map
     ) {
     }
 

--- a/src/main/java/com/skala/nav7/api/session/exception/FastAPIErrorCode.java
+++ b/src/main/java/com/skala/nav7/api/session/exception/FastAPIErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum FastAPIErrorCode implements BaseErrorCode {
+    RESPONSE_JSON_PARSING_ERROR(HttpStatus.BAD_REQUEST, "FAST_API_JSON_500", "AI Agent 응답 파싱 중 오류가 발생했습니다."),
     FAST_API_ERROR(HttpStatus.BAD_REQUEST, "FAST_API_500", "AI Agent 응답 생성 중 오류가 발생했습니다."),
     ;
     private final HttpStatus status;

--- a/src/main/java/com/skala/nav7/api/session/service/FastApiClientService.java
+++ b/src/main/java/com/skala/nav7/api/session/service/FastApiClientService.java
@@ -23,15 +23,15 @@ public class FastApiClientService {
     private final static String GENERAL_CHAT_URL = "/career-path";
     private final static String CAREER_TITLE_URL = "/career-title";
 
-    public FastAPIResponseDTO.CareerResponseDTO askCareerPath(Long profileId, String question) {
+    public FastAPIResponseDTO askCareerPath(Long profileId, String question, String sessionId) {
         try {
             return fastApiWebClient.post()
                     .uri(GENERAL_CHAT_URL)
-                    .bodyValue(FastAPIRequestDTO.CareerPathRequestDTO.of(profileId, question))
+                    .bodyValue(FastAPIRequestDTO.CareerPathRequestDTO.of(profileId, question, sessionId))
                     .retrieve()
                     .onStatus(HttpStatusCode::isError, this::handleError)
-                    .bodyToMono(FastAPIResponseDTO.CareerResponseDTO.class)
-                    .doOnError(e -> log.error("FAST API ERROR: {} ", e.getMessage()))
+                    .bodyToMono(FastAPIResponseDTO.class)
+                    .doOnError(e -> log.error("FAST API ERROR", e))
                     .block();
         } catch (Exception e) {
             throw new FastAPIException(FastAPIErrorCode.FAST_API_ERROR);

--- a/src/main/java/com/skala/nav7/api/session/service/SessionService.java
+++ b/src/main/java/com/skala/nav7/api/session/service/SessionService.java
@@ -1,49 +1,109 @@
 package com.skala.nav7.api.session.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.skala.nav7.api.member.entity.Member;
 import com.skala.nav7.api.session.converter.SessionConverter;
 import com.skala.nav7.api.session.dto.request.SessionMessageRequestDTO;
 import com.skala.nav7.api.session.dto.request.SessionRequestDTO;
+import com.skala.nav7.api.session.dto.response.FastAPIResponseDTO;
+import com.skala.nav7.api.session.dto.response.FastAPIResponseDTO.RoleModelDTO;
 import com.skala.nav7.api.session.dto.response.SessionMessageResponseDTO;
 import com.skala.nav7.api.session.dto.response.SessionResponseDTO;
 import com.skala.nav7.api.session.entity.Session;
 import com.skala.nav7.api.session.entity.SessionMessage;
+import com.skala.nav7.api.session.exception.FastAPIErrorCode;
+import com.skala.nav7.api.session.exception.FastAPIException;
 import com.skala.nav7.api.session.exception.SessionErrorCode;
 import com.skala.nav7.api.session.exception.SessionException;
 import com.skala.nav7.api.session.repository.SessionMessageRepository;
 import com.skala.nav7.api.session.repository.SessionRepository;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class SessionService {
     private final SessionRepository sessionRepository;
     private final SessionMessageRepository sessionMessageRepository;
     private final FastApiClientService fastApiClientService;
     private final MongoTemplate mongoTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String SESSION_ID = "sessionId";
+    private static final String AGENT_ROLE_MODEL = "RoleModel";
+    private static final String KEY_PROFILE_ID = "profileId_";
+    private static final String KEY_SCORE = "score_";
+    private static final String KEY_RESPONSE = "response";
+    private static final String KEY_RAW = "raw";
 
     public SessionResponseDTO.newSessionDTO createNewSessions(Member member, SessionRequestDTO.newSessionDTO dto) {
         Session session = Session.builder().member(member).sessionTitle(dto.question()).build();
-        String answer = fastApiClientService.askCareerPath(dto.question());
         sessionRepository.save(session);
-        SessionMessage message = SessionMessage.builder().sessionId(session.getId().toString())
-                .createdAt(LocalDateTime.now())
-                .createdAt(session.getCreatedAt())
-                .answer(answer).question(
-                        dto.question()).build();
-        sessionMessageRepository.save(message);
-        return SessionConverter.to(session.getId(), answer);
+        HashMap<String, String> map = getSessionMessage(member.getId(), dto.question(),
+                String.valueOf(session.getId()));
+        return SessionConverter.to(session.getId(), map);
+    }
+
+    private HashMap<String, String> getSessionMessage(Long profileId, String question,
+                                                      String sessionId) {
+        FastAPIResponseDTO response = fastApiClientService.askCareerPath(profileId, question,
+                sessionId);
+
+        if (!response.content().success()) {
+            throw new FastAPIException(FastAPIErrorCode.FAST_API_ERROR);
+        }
+
+        String agent = response.content().result().agent();
+        JsonNode textNode = response.content().result().text();
+
+        HashMap<String, String> map = new HashMap<>();
+
+        try {
+            if (AGENT_ROLE_MODEL.equals(agent) && textNode.isArray()) {
+                List<RoleModelDTO> roleModels = objectMapper.readValue(
+                        textNode.toString(),
+                        objectMapper.getTypeFactory().constructCollectionType(List.class, RoleModelDTO.class)
+                );
+                for (int i = 0; i < roleModels.size(); i++) {
+                    RoleModelDTO rm = roleModels.get(i);
+                    map.put(KEY_PROFILE_ID + i, String.valueOf(rm.profileId()));
+                    map.put(KEY_SCORE + i, String.valueOf(rm.similarity_score()));
+                }
+            } else if (textNode.isTextual()) {
+                map.put(KEY_RESPONSE, textNode.asText());
+            } else {
+                map.put(KEY_RAW, textNode.toString()); // fallback
+            }
+
+            SessionMessage message = SessionMessage.builder()
+                    .sessionId(sessionId)
+                    .createdAt(LocalDateTime.now())
+                    .question(question)
+                    .answer(objectMapper.writeValueAsString(map))
+                    .build();
+            sessionMessageRepository.save(message);
+            return map;
+        } catch (JsonProcessingException e) {
+            throw new FastAPIException(FastAPIErrorCode.RESPONSE_JSON_PARSING_ERROR);
+        } catch (Exception e) {
+            log.error("❌ 메시지 저장 실패", e);
+            throw e;
+        }
     }
 
     public Slice<Session> getSessionList(Member member, LocalDateTime cursorAt, UUID cursorId, int size) {
@@ -58,41 +118,43 @@ public class SessionService {
     public SessionMessageResponseDTO.newMessageDTO createNewMessage(Member member, UUID sessionId,
                                                                     SessionMessageRequestDTO.newMessageDTO dto) {
         Session session = getSession(sessionId);
-        String answer = fastApiClientService.askCareerPath(dto.question());
-        SessionMessage message = SessionMessage.builder().sessionId(String.valueOf(session.getId()))
-                .createdAt(session.getCreatedAt())
-                .answer(answer).question(
-                        dto.question()).build();
-        sessionMessageRepository.save(message);
-        return SessionConverter.toMessage(session.getId(), answer);
+        HashMap<String, String> map = getSessionMessage(member.getId(), dto.question(),
+                String.valueOf(session.getId())); //todo:memberId 를 profileId로 수정
+        return SessionConverter.toMessage(session.getId(), map);
     }
 
     public SessionMessageResponseDTO.SessionDetailDTO getSessionMessageList(Member member, UUID sessionId,
                                                                             String cursor, int size) {
         Session session = getSession(sessionId);
+        checkMemberAuth(member, session);
         Query query = new Query();
-        query.addCriteria(Criteria.where("sessionId").is(sessionId.toString())); //해당 SessionId만 가져옴
+        query.addCriteria(Criteria.where(SESSION_ID).is(sessionId.toString())); //해당 SessionId만 가져옴
         //커서이후의 데이터만 필터링한다
         if (cursor != null && !cursor.isEmpty()) {
             query.addCriteria(Criteria.where("_id").gt(new ObjectId(cursor)));
         }
-        query.with(Sort.by(Sort.Direction.ASC, "_id")); //_id 오름차순 필터링
+        query.with(Sort.by(Direction.ASC, "_id")); //_id 오름차순 필터링
         query.limit(size + 1); //조회 갯수 제한
         List<SessionMessage> messages = mongoTemplate.find(query, SessionMessage.class);
 
         return SessionConverter.to(session, messages, size);
     }
 
+
     public void deleteSession(Member member, UUID sessionId) {
         Session session = getSession(sessionId);
-        if (!session.getMember().equals(member)) {
-            throw new SessionException(SessionErrorCode.NOT_HAVE_AUTHORIZATION);
-        }
+        checkMemberAuth(member, session);
         sessionRepository.delete(session);
 
         Query query = new Query();
-        query.addCriteria(Criteria.where("sessionId").is(sessionId.toString())); // 특정 세션의 메시지 전부
+        query.addCriteria(Criteria.where(SESSION_ID).is(sessionId.toString())); // 특정 세션의 메시지 전부
         mongoTemplate.remove(query, SessionMessage.class);
+    }
+
+    private static void checkMemberAuth(Member member, Session session) {
+        if (!session.getMember().equals(member)) {
+            throw new SessionException(SessionErrorCode.NOT_HAVE_AUTHORIZATION);
+        }
     }
 
     private Session getSession(UUID sessionId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## 🔥 작업 개요
- Session 응답 FAST API 의 스키마로 변경

## ✅ 관련 이슈
- close #15 

## ✨ 주요 변경사항
- 응답 - > DTO
- 요청 -> DTO
- 근데 profile API 구현 후에 다시 todo 부분 수정해야 될듯

## 📸 스크린샷(선택)

## 🧪 테스트 (선택)
- [ ] 로컬에서 테스트 완료
- [ ] 테스트 코드 실행 (`./gradlew test`)

## 📝 ETC (선택)
