### PR TITLE
[Feat] rolemodel response에 랜덤 이름 값 추가 

### DIFF
--- a/src/main/java/com/skala/nav7/api/member/entity/Member.java
+++ b/src/main/java/com/skala/nav7/api/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.skala.nav7.api.member.entity;
 
+import com.skala.nav7.api.profile.entity.Profile;
 import com.skala.nav7.global.base.entity.SoftDeletableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -46,4 +48,6 @@ public class Member extends SoftDeletableEntity {
 
     @Column(name = "member_name", nullable = false)
     String memberName;
+    @OneToOne(mappedBy = "member")
+    private Profile profile;
 }

--- a/src/main/java/com/skala/nav7/api/session/service/RandomNameCreator.java
+++ b/src/main/java/com/skala/nav7/api/session/service/RandomNameCreator.java
@@ -1,0 +1,36 @@
+package com.skala.nav7.api.session.service;
+
+import java.util.List;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RandomNameCreator {
+
+    private static final List<String> LAST_NAMES = List.of(
+            "김", "이", "박", "최", "정", "강", "조", "윤", "장", "임", "한", "오", "서", "신", "권", "황", "안", "송", "류", "홍", "노",
+            "양", "백", "문", "전", "허", "남", "심", "구", "하", "진", "곽", "성", "차", "주", "우", "구", "나", "민", "유", "나", "백"
+    );
+
+    private static final List<String> FIRST_NAME_PART1 = List.of(
+            "가", "나", "다", "라", "마", "바", "사", "하", "윤", "수", "은", "채", "예", "다", "준", "성", "연", "영", "주", "재", "현",
+            "유", "아", "혜", "지", "도", "태", "승", "소", "지", "선", "시", "지", "슬", "진", "명", "동", "형"
+    );
+
+    private static final List<String> FIRST_NAME_PART2 = List.of(
+            "은", "진", "우", "빈", "정", "현", "희", "림", "영", "연", "훈", "석", "찬", "혁", "결", "율", "서", "나", "예", "솔",
+            "환", "겸", "경", "진", "재", "온", "해", "담", "민", "범", "범", "슬", "우", "재", "정", "혁", "하", "영"
+    );
+
+    private final Random random = new Random();
+
+    public String create() {
+        StringBuilder name = new StringBuilder();
+        String lastName = LAST_NAMES.get(random.nextInt(LAST_NAMES.size()));
+        String firstName1 = FIRST_NAME_PART1.get(random.nextInt(FIRST_NAME_PART1.size()));
+        String firstName2 = FIRST_NAME_PART2.get(random.nextInt(FIRST_NAME_PART2.size()));
+        return name.append(lastName).append(firstName1).append(firstName2).toString();
+    }
+}

--- a/src/test/java/com/skala/nav7/api/session/service/FastApiClientServiceTest.java
+++ b/src/test/java/com/skala/nav7/api/session/service/FastApiClientServiceTest.java
@@ -1,21 +1,31 @@
 package com.skala.nav7.api.session.service;
 
+import com.skala.nav7.api.session.dto.response.FastAPIResponseDTO;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
 class FastApiClientServiceTest {
-//    private FastApiClientService service;
-//    private static String FAST_API_URL = "https://sk-nav7.skala25a.project.skala-ai.com/apis/v1/";
-//
-//    @BeforeEach
-//    void setUp() {
-//        WebClient client = WebClient.builder()
-//                .baseUrl(FAST_API_URL)
-//                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-//                .build();
-//        service = new FastApiClientService(client);
-//    }
-//
-//    @Test
-//    void askCareerPath() {
-//        String answer = service.askCareerPath("Cloud 천재가 되기 위해선 어떻게 해?");
-//        Assertions.assertEquals("\"커리어추천: cloud 강의 듣기\"", answer);
-//    }
+    private FastApiClientService service;
+    private static String FAST_API_URL = "https://sk-nav7.skala25a.project.skala-ai.com/apis/v1/";
+
+    @BeforeEach
+    void setUp() {
+        WebClient client = WebClient.builder()
+                .baseUrl(FAST_API_URL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        service = new FastApiClientService(client);
+    }
+
+    @Test
+    void askCareerPath() {
+        FastAPIResponseDTO response = service.askCareerPath(1L, "클라우드 고수 롤모델 추천해줘.", String.valueOf(UUID.randomUUID()));
+        Assertions.assertTrue(response.content().success());
+        Assertions.assertEquals(response.content().result().agent(), "RoleModel");
+    }
 }

--- a/src/test/java/com/skala/nav7/api/session/service/RandomNameCreatorTest.java
+++ b/src/test/java/com/skala/nav7/api/session/service/RandomNameCreatorTest.java
@@ -1,0 +1,35 @@
+package com.skala.nav7.api.session.service;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RandomNameCreatorTest {
+    private RandomNameCreator randomNameCreator;
+
+    @BeforeEach
+    void setUp() {
+        this.randomNameCreator = new RandomNameCreator();
+    }
+
+    @Test
+    void 랜덤으로_세글자_이름을_생성한다() {
+        String randomName = randomNameCreator.create();
+        System.out.println(randomName);
+        Assertions.assertEquals(3, randomName.length());
+    }
+
+    @Test
+    void 랜덤_이름_10개_생성시_모두_다르다() {
+        Set<String> nameSet = new HashSet<>();
+        for (int i = 0; i < 10; i++) {
+            String name = randomNameCreator.create();
+            Assertions.assertEquals(3, name.length(), "이름 길이는 3글자여야 한다");
+            nameSet.add(name);
+        }
+
+        Assertions.assertEquals(10, nameSet.size(), "10개의 랜덤 이름이 모두 달라야 한다");
+    }
+}


### PR DESCRIPTION
## 🔥 작업 개요
- session service에 응답을 받고 파싱한 후, 응답 json 값에 랜덤으로 생성한 이름을 추가했습니다.
-  세글자의 랜덤 이름 생성 역할을 하는 RandomNameCreator 서비스를 만들었습니다.
-  단위 테스트 완료했습니다

## ✅ 관련 이슈
- close #23

## ✨ 주요 변경사항

- [test(RandomName): 3글자 랜덤 롤모델 이름 생성 test](https://github.com/Nav7-SKALA/nav-be/commit/b4a517638883a4c3e47d3a221e5ecf3b6a1d0120)
- [feat(RandomName): 3글자 랜덤 롤모델 이름 생성 서비스 구현](https://github.com/Nav7-SKALA/nav-be/commit/ed47d6f7239f85181d47e5913da12fc086034b72)
- [test(FastAPI): fastapi rolemodel 응답 health check test](https://github.com/Nav7-SKALA/nav-be/commit/163ada25baeddefb086ce86b08165aa01c660c0b)
- [feat(session): random nickname 응답에 포함하는 로직 추가](https://github.com/Nav7-SKALA/nav-be/commit/f68dbbada35f33760bd2600d8171367617a15c14)

## 📸 스크린샷(선택)

## 🧪 테스트 (선택)
- [x] 로컬에서 테스트 완료
- [x] 테스트 코드 실행 (`./gradlew test`)

## 📝 ETC (선택)
