### PR TITLE
[Feat] Experience CRUD API 구현

### DIFF
--- a/src/main/java/com/skala/nav7/api/experience/controller/ExperienceController.java
+++ b/src/main/java/com/skala/nav7/api/experience/controller/ExperienceController.java
@@ -1,0 +1,92 @@
+package com.skala.nav7.api.experience.controller;
+
+import com.skala.nav7.api.experience.converter.ExperienceConverter;
+import com.skala.nav7.api.experience.dto.request.ExperienceRequestDTO;
+import com.skala.nav7.api.experience.dto.response.ExperienceResponseDTO;
+import com.skala.nav7.api.experience.entity.Experience;
+import com.skala.nav7.api.experience.service.ExperienceService;
+import com.skala.nav7.api.profile.entity.Profile;
+import com.skala.nav7.global.apiPayload.ApiResponse;
+import com.skala.nav7.global.auth.jwt.annotation.ProfileEntity;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/profiles")
+@Tag(name = "경험 Experience 관련 API", description = "사용자 경험 관련 API 입니다.")
+public class ExperienceController {
+    private final ExperienceService experienceService;
+
+    @Operation(
+            summary = "내 경험 불러오기",
+            description = "내 경험 전체를 불러옵니다."
+    )
+    @GetMapping(value = "/me/experiences")
+    public ApiResponse<?> getExperience(
+            @ProfileEntity Profile profile,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "4") int size
+    ) {
+        return ApiResponse.onSuccess(experienceService.getPaginatedExperience(profile, page, size));
+    }
+
+    @Operation(
+            summary = "경험 만들기",
+            description = "새 경험을 만듭니다."
+    )
+    @PostMapping(value = "/me/experience")
+    public ResponseEntity<ApiResponse<ExperienceResponseDTO.DefaultInfoDTO>> createExperience(
+            @ProfileEntity Profile profile,
+            @RequestBody @Valid ExperienceRequestDTO.CreateExperienceDTO request
+    ) {
+        Experience experience = experienceService.createNewExperience(profile, request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.of(ExperienceSuccessCode.EXPERIENCE_CREATED,
+                        ExperienceConverter.to(experience)));
+    }
+
+    @Operation(
+            summary = "내 경험 수정하기",
+            description = "해당하는 아이디의 경험을 수정합니다."
+    )
+    @PutMapping(value = "/me/experiences/{experiencesId}")
+    public ApiResponse<?> editExperience(
+            @Parameter(description = "수정하려는 experience 의 ID") @PathVariable Long experiencesId,
+            @ProfileEntity Profile profile,
+            @RequestBody ExperienceRequestDTO.UpdateExperienceDTO request
+    ) {
+
+        return ApiResponse.onSuccess(
+                ExperienceConverter.to(experienceService.editExperience(profile, experiencesId, request)));
+    }
+
+    @Operation(
+            summary = "내 경험 삭제하기",
+            description = "해당하는 아이디의 경험을 삭제합니다."
+    )
+    @PostMapping(value = "/me/experiences/{experiencesId}")
+    public ResponseEntity<ApiResponse<?>> deleteExperience(
+            @Parameter(description = "삭제하려는 experience 의 ID") @PathVariable Long experiencesId,
+            @ProfileEntity Profile profile
+    ) {
+        experienceService.deleteExperience(experiencesId, profile);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.onSuccess(ExperienceSuccessCode.EXPERIENCE_DELETED));
+    }
+}

--- a/src/main/java/com/skala/nav7/api/experience/controller/ExperienceSuccessCode.java
+++ b/src/main/java/com/skala/nav7/api/experience/controller/ExperienceSuccessCode.java
@@ -1,0 +1,27 @@
+package com.skala.nav7.api.experience.controller;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseCode;
+import com.skala.nav7.global.apiPayload.dto.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ExperienceSuccessCode implements BaseCode {
+    EXPERIENCE_CREATED(HttpStatus.CREATED, "EXPERIENCE201", "경험 생성이 완료되었습니다."),
+    EXPERIENCE_DELETED(HttpStatus.NO_CONTENT, "EXPERIENCE204", "경험이 삭제되었습니다.");
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .httpStatus(this.status)
+                .isSuccess(false)
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/experience/converter/ExperienceConverter.java
+++ b/src/main/java/com/skala/nav7/api/experience/converter/ExperienceConverter.java
@@ -1,0 +1,15 @@
+package com.skala.nav7.api.experience.converter;
+
+import com.skala.nav7.api.experience.dto.response.ExperienceResponseDTO;
+import com.skala.nav7.api.experience.entity.Experience;
+
+public class ExperienceConverter {
+    public static ExperienceResponseDTO.DefaultInfoDTO to(Experience experience) {
+        return ExperienceResponseDTO.DefaultInfoDTO.builder()
+                .experienceId(experience.getId())
+                .experienceDescribe(experience.getExperienceDescribe())
+                .experienceName(experience.getExperienceName())
+                .experiencedAt(experience.getExperiencedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/experience/dto/request/ExperienceRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/experience/dto/request/ExperienceRequestDTO.java
@@ -1,0 +1,40 @@
+package com.skala.nav7.api.experience.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Optional;
+
+public record ExperienceRequestDTO(
+) {
+    @Schema(description = "경험 생성 요청 DTO")
+    public record CreateExperienceDTO(
+
+            @NotBlank(message = "경험 명을 입력해주세요.")
+            @Schema(description = "경험 명", example = "AWS SUMMIT")
+            String experienceName,
+
+            @NotBlank(message = "경험 설명을 입력해주세요.")
+            @Schema(description = "경험 설명", example = "AWS SUMMIT 참여했다! 재밌었다.")
+            String experienceDescribe,
+
+            @NotNull(message = "경험한 년도를 입력해주세요.")
+            @Schema(description = "경험 년도", example = "2022-05-01")
+            LocalDate experiencedAt
+    ) {
+    }
+
+    @Schema(description = "경험 수정 요청 DTO")
+    public record UpdateExperienceDTO(
+
+            @Schema(description = "경험 명", example = "AWS SUMMIT")
+            Optional<String> experienceName,
+
+            @Schema(description = "경험 설명", example = "AWS SUMMIT 참여했다! 재밌었다.")
+            Optional<String> experienceDescribe,
+            @Schema(description = "경험 년도", example = "2022-05-01")
+            Optional<LocalDate> experiencedAt
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/experience/dto/response/ExperienceResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/experience/dto/response/ExperienceResponseDTO.java
@@ -1,0 +1,25 @@
+package com.skala.nav7.api.experience.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Builder;
+
+public record ExperienceResponseDTO() {
+    @Builder
+    @Schema(description = "경험 기본 정보 응답 DTO")
+    public record DefaultInfoDTO(
+            @Schema(description = "경험 ID", example = "1")
+            Long experienceId,
+
+            @Schema(description = "경험 이름", example = "AWS Game Day")
+            String experienceName,
+
+            @Schema(description = "경험 묘사", example = "2024년 AWS Game Day 에 참여해서 LOL 우승 승부 예측을 했다. 10등으로 마무리했다. ")
+            String experienceDescribe,
+
+            @Schema(description = "경험 년도", example = "2022.05")
+            LocalDate experiencedAt
+
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/experience/entity/Experience.java
+++ b/src/main/java/com/skala/nav7/api/experience/entity/Experience.java
@@ -9,7 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -18,6 +18,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -26,21 +27,31 @@ import lombok.experimental.FieldDefaults;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @Table(name = "experience")
+@SQLRestriction("deleted_at IS NULL")
 public class Experience extends SoftDeletableEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "experience_id", nullable = false)
     Long id;
-
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_id", nullable = false)
     Profile profile;
-
     @Column(name = "experience_name")
     String experienceName;
     @Column(name = "experience_describe")
     String experienceDescribe;
-
     @Column(name = "experienced_at")
     LocalDate experiencedAt;
+
+    public void updateExperienceName(String experienceName) {
+        this.experienceName = experienceName;
+    }
+
+    public void updateExperienceDescribe(String experienceDescribe) {
+        this.experienceDescribe = experienceDescribe;
+    }
+
+    public void updateExperiencedAt(LocalDate experiencedAt) {
+        this.experiencedAt = experiencedAt;
+    }
 }

--- a/src/main/java/com/skala/nav7/api/experience/error/ExperienceErrorCode.java
+++ b/src/main/java/com/skala/nav7/api/experience/error/ExperienceErrorCode.java
@@ -1,0 +1,31 @@
+package com.skala.nav7.api.experience.error;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.apiPayload.dto.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ExperienceErrorCode implements BaseErrorCode {
+    EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXPERIENCE404", "해당 경험이 존재하지 않습니다."),
+
+    // ─── 권한 및 인증 오류 ─────────────────
+    UNAUTHORIZED_EXPERIENCE_ACCESS(HttpStatus.FORBIDDEN, "EXPERIENCE403", "해당 경험에 접근 권한이 없습니다."),
+
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .httpStatus(this.status)
+                .isSuccess(false)
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/experience/error/ExperienceException.java
+++ b/src/main/java/com/skala/nav7/api/experience/error/ExperienceException.java
@@ -1,0 +1,11 @@
+package com.skala.nav7.api.experience.error;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.exception.GeneralException;
+
+public class ExperienceException extends GeneralException {
+
+    public ExperienceException(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/skala/nav7/api/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/skala/nav7/api/experience/repository/ExperienceRepository.java
@@ -2,9 +2,13 @@ package com.skala.nav7.api.experience.repository;
 
 
 import com.skala.nav7.api.experience.entity.Experience;
+import com.skala.nav7.api.profile.entity.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+    Page<Experience> findAllByProfile(Profile profile, Pageable pageable);
 }

--- a/src/main/java/com/skala/nav7/api/experience/service/ExperienceService.java
+++ b/src/main/java/com/skala/nav7/api/experience/service/ExperienceService.java
@@ -1,0 +1,92 @@
+package com.skala.nav7.api.experience.service;
+
+import com.skala.nav7.api.experience.converter.ExperienceConverter;
+import com.skala.nav7.api.experience.dto.request.ExperienceRequestDTO;
+import com.skala.nav7.api.experience.dto.response.ExperienceResponseDTO;
+import com.skala.nav7.api.experience.entity.Experience;
+import com.skala.nav7.api.experience.error.ExperienceErrorCode;
+import com.skala.nav7.api.experience.error.ExperienceException;
+import com.skala.nav7.api.experience.repository.ExperienceRepository;
+import com.skala.nav7.api.profile.entity.Profile;
+import com.skala.nav7.global.apiPayload.pagenation.PageResponse;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExperienceService {
+    private final ExperienceRepository experienceRepository;
+    private static final String EXPERIENCE_AT = "experiencedAt";
+
+    public PageResponse<ExperienceResponseDTO.DefaultInfoDTO> getPaginatedExperience(Profile profile, int page,
+                                                                                     int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(EXPERIENCE_AT).ascending());
+        Page<Experience> experiences = experienceRepository.findAllByProfile(profile, pageRequest);
+        List<ExperienceResponseDTO.DefaultInfoDTO> contents = experiences.getContent().stream()
+                .map(ExperienceConverter::to)
+                .toList();
+        return PageResponse.of(contents, experiences);
+    }
+
+    public Experience createNewExperience(Profile profile, ExperienceRequestDTO.CreateExperienceDTO request) {
+        Experience experience = Experience.builder()
+                .profile(profile)
+                .experienceName(request.experienceName())
+                .experienceDescribe(request.experienceDescribe())
+                .experiencedAt(request.experiencedAt())
+                .build();
+        return experienceRepository.save(experience);
+    }
+
+    @Transactional
+    public Experience editExperience(Profile profile, Long experienceId,
+                                     ExperienceRequestDTO.UpdateExperienceDTO request) {
+        Experience experience = getExperience(profile, experienceId);
+
+        // 경험명 수정
+        if (request.experienceName().isPresent()) {
+            String newName = request.experienceName().get();
+            experience.updateExperienceName(newName);
+        }
+
+        // 경험 설명 수정
+        if (request.experienceDescribe().isPresent()) {
+            String newDescribe = request.experienceDescribe().get();
+            experience.updateExperienceDescribe(newDescribe);
+        }
+
+        // 경험 날짜 수정
+        if (request.experiencedAt().isPresent()) {
+            LocalDate newDate = request.experiencedAt().get();
+            experience.updateExperiencedAt(newDate);
+        }
+
+        return experienceRepository.save(experience);
+    }
+
+
+    private Experience getExperience(Profile profile, Long experienceId) {
+        Experience experience = experienceRepository.findById(experienceId).orElseThrow(
+                () -> new ExperienceException(ExperienceErrorCode.EXPERIENCE_NOT_FOUND)
+        );
+        if (!experience.getProfile().equals(profile)) {
+            throw new ExperienceException(ExperienceErrorCode.UNAUTHORIZED_EXPERIENCE_ACCESS);
+        }
+        return experience;
+    }
+
+    @Transactional
+    public void deleteExperience(Long experienceId, Profile profile) {
+        Experience experience = getExperience(profile, experienceId);
+        experience.delete();
+        experienceRepository.save(experience);
+    }
+
+
+}


### PR DESCRIPTION
## 🔥 작업 개요
- Experience(경험) 엔티티에 대한 부분 수정(PATCH) API 구현
- Optional을 활용한 선택적 필드 업데이트 기능 추가

## ✅ 관련 이슈
- close #25 

## ✨ 주요 변경사항

- DTO 수정: UpdateExperienceDTO에서 Optional<T> 타입을 사용하여 부분 수정 지원
- 서비스 로직 구현: editExperience 메서드에서 Optional 값 존재 여부 확인 후 선택적 업데이트
- 엔티티 업데이트 메서드 추가: Experience 엔티티에 각 필드별 업데이트 메서드 구현
- 소프트 삭제 지원: @SQLRestriction("deleted_at IS NULL") 어노테이션 추가로 삭제된 데이터 자동 필터링
- 검증 로직: Optional 타입 특성상 Bean Validation 대신 서비스 레이어에서 수동 검증 처리

## 📸 스크린샷(선택)

## 🧪 테스트 (선택)
- [x] 로컬에서 테스트 완료
- [x] 테스트 코드 실행 (`./gradlew test`)

## 📝 ETC (선택)
