### PR TITLE
[Feat] certification 관련 API 구현

### DIFF
--- a/src/main/java/com/skala/nav7/api/certification/controller/CertificationController.java
+++ b/src/main/java/com/skala/nav7/api/certification/controller/CertificationController.java
@@ -1,0 +1,53 @@
+package com.skala.nav7.api.certification.controller;
+
+import com.skala.nav7.api.certification.dto.response.CertificationResponseDTO;
+import com.skala.nav7.api.certification.dto.response.CertificationResponseDTO.DefaultInfoDTO;
+import com.skala.nav7.api.certification.service.CertificationService;
+import com.skala.nav7.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/certifications")
+@Tag(name = "자격증 Certification 관련 API", description = "마스터 테이블의 자격증 관련 API입니다.")
+public class CertificationController {
+
+    private final CertificationService certificationService;
+
+    @Operation(summary = "자격증 이름 검색", description = "입력한 키워드를 포함하는 자격증을 검색합니다.")
+    @GetMapping("/search")
+    public ApiResponse<List<DefaultInfoDTO>> searchCertifications(
+            @Parameter(description = "검색할 단어") @RequestParam String query
+    ) {
+        return ApiResponse.onSuccess(certificationService.searchCertifications(query));
+    }
+
+    @Operation(
+            summary = "자격증 추가",
+            description = "새로운 자격증을 마스터 테이블에 추가합니다."
+    )
+    @PostMapping("/add")
+    public ResponseEntity<ApiResponse<CertificationResponseDTO.DefaultInfoDTO>> addCertification(
+            @Parameter(description = "자격증 명") @RequestParam @NotBlank(message = "자격증 명을 입력해주세요.") String certificationName
+    ) {
+        CertificationResponseDTO.DefaultInfoDTO response =
+                certificationService.createCertificationIfNotExists(certificationName);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.onSuccess(response));
+    }
+
+}

--- a/src/main/java/com/skala/nav7/api/certification/converter/CertificationConverter.java
+++ b/src/main/java/com/skala/nav7/api/certification/converter/CertificationConverter.java
@@ -1,0 +1,14 @@
+package com.skala.nav7.api.certification.converter;
+
+import com.skala.nav7.api.certification.memberCertification.dto.response.MemberCertificationResponseDTO;
+import com.skala.nav7.api.certification.memberCertification.entity.MemberCertification;
+
+public class CertificationConverter {
+    public static MemberCertificationResponseDTO.DefaultInfoDTO to(MemberCertification memberCertification) {
+        return MemberCertificationResponseDTO.DefaultInfoDTO.builder()
+                .certificationId(memberCertification.getId())
+                .certificationName(memberCertification.getCertification().getCertificationName())
+                .acquisitionDate(memberCertification.getAcquisitionDate())
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/dto/request/CertificationRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/certification/dto/request/CertificationRequestDTO.java
@@ -1,0 +1,14 @@
+package com.skala.nav7.api.certification.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CertificationRequestDTO() {
+    @Schema(description = "자격증 생성 요청 DTO")
+    public record CreateCertificationDTO(
+            @NotBlank(message = "자격증 명을 입력해주세요.")
+            @Schema(description = "자격증 명", example = "정보처리기사")
+            String certificationName
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/dto/response/CertificationResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/certification/dto/response/CertificationResponseDTO.java
@@ -1,0 +1,13 @@
+package com.skala.nav7.api.certification.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CertificationResponseDTO() {
+    public record DefaultInfoDTO(
+            @Schema(description = "자격증 아이디", example = "1")
+            Long certificationId,
+            @Schema(description = "자격증 이름", example = "정보처리기사")
+            String certificationName
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/entity/Certification.java
+++ b/src/main/java/com/skala/nav7/api/certification/entity/Certification.java
@@ -27,6 +27,6 @@ public class Certification {
     @Column(name = "certification_id")
     Long id;
 
-    @Column(name = "certification_name", nullable = false)
+    @Column(name = "certification_name", nullable = false, unique = true)
     String certificationName;
 }

--- a/src/main/java/com/skala/nav7/api/certification/error/CertificationErrorCode.java
+++ b/src/main/java/com/skala/nav7/api/certification/error/CertificationErrorCode.java
@@ -1,0 +1,31 @@
+package com.skala.nav7.api.certification.error;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.apiPayload.dto.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CertificationErrorCode implements BaseErrorCode {
+    MEMBER_CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "CERTIFICATION404", "해당 회원 자격증이 존재하지 않습니다."),
+    ALREADY_EXIST_CERTIFICATION(HttpStatus.CONFLICT, "CERTIFICATION409", "이미 해당 자격증이 존재합니다."),
+    CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "CERTIFICATION404", "해당 자격증이 존재하지 않습니다."),
+    UNAUTHORIZED_CERTIFICATION_ACCESS(HttpStatus.FORBIDDEN, "CERTIFICATION403", "해당 자격증에 접근 권한이 없습니다."),
+
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .httpStatus(this.status)
+                .isSuccess(false)
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/error/CertificationException.java
+++ b/src/main/java/com/skala/nav7/api/certification/error/CertificationException.java
@@ -1,0 +1,11 @@
+package com.skala.nav7.api.certification.error;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseErrorCode;
+import com.skala.nav7.global.exception.GeneralException;
+
+public class CertificationException extends GeneralException {
+
+    public CertificationException(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/error/CertificationSuccessCode.java
+++ b/src/main/java/com/skala/nav7/api/certification/error/CertificationSuccessCode.java
@@ -1,0 +1,27 @@
+package com.skala.nav7.api.certification.error;
+
+import com.skala.nav7.global.apiPayload.code.base.BaseCode;
+import com.skala.nav7.global.apiPayload.dto.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CertificationSuccessCode implements BaseCode {
+    CERTIFICATION_CREATED(HttpStatus.CREATED, "EXPERIENCE201", "자격증 생성이 완료되었습니다."),
+    CERTIFICATION_DELETED(HttpStatus.NO_CONTENT, "EXPERIENCE204", "자격증이 삭제되었습니다.");
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .httpStatus(this.status)
+                .isSuccess(false)
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/memberCertification/controller/MemberCertificationController.java
+++ b/src/main/java/com/skala/nav7/api/certification/memberCertification/controller/MemberCertificationController.java
@@ -1,0 +1,83 @@
+package com.skala.nav7.api.certification.memberCertification.controller;
+
+import com.skala.nav7.api.certification.entity.Certification;
+import com.skala.nav7.api.certification.error.CertificationSuccessCode;
+import com.skala.nav7.api.certification.memberCertification.dto.request.MemberCertificationRequestDTO;
+import com.skala.nav7.api.certification.memberCertification.dto.response.MemberCertificationResponseDTO;
+import com.skala.nav7.api.certification.memberCertification.entity.MemberCertification;
+import com.skala.nav7.api.certification.service.CertificationService;
+import com.skala.nav7.api.certification.service.MemberCertificationService;
+import com.skala.nav7.api.profile.entity.Profile;
+import com.skala.nav7.global.apiPayload.ApiResponse;
+import com.skala.nav7.global.apiPayload.pagenation.PageResponse;
+import com.skala.nav7.global.auth.jwt.annotation.ProfileEntity;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/profiles")
+@Tag(name = "자격증 Certification 관련 API", description = "사용자의 자격증 관련 API입니다.")
+public class MemberCertificationController {
+
+    private final MemberCertificationService memberCertificationService;
+    private final CertificationService certificationService;
+
+    @Operation(
+            summary = "내 자격증 전체 조회",
+            description = "사용자의 자격증 리스트를 조회합니다."
+    )
+    @GetMapping("/me/certifications")
+    public ApiResponse<PageResponse<MemberCertificationResponseDTO.DefaultInfoDTO>> getMyCertifications(
+            @ProfileEntity Profile profile,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "8") int size
+    ) {
+        return ApiResponse.onSuccess(
+                memberCertificationService.getMemberCertifications(profile, page, size));
+    }
+
+    @Operation(
+            summary = "회원 자격증 생성",
+            description = "해당 자격증을 사용자의 자격증으로 추가합니다."
+    )
+    @PostMapping("/me/certifications")
+    public ResponseEntity<ApiResponse<?>> createNewMemberCertification(
+            @ProfileEntity Profile profile,
+            @Parameter(description = "사용자 자격증 정보") @RequestBody MemberCertificationRequestDTO.CreateCertificationDTO request
+    ) {
+        Certification certification = certificationService.getCertification(request.certificationId());
+        MemberCertification memberCertification = memberCertificationService.createNewMemberCertification(profile,
+                request, certification);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.onSuccess(CertificationSuccessCode.CERTIFICATION_CREATED));
+    }
+
+    @Operation(
+            summary = "자격증 삭제",
+            description = "해당 자격증을 사용자의 자격증 목록에서 삭제합니다. (hard delete)"
+    )
+    @DeleteMapping("/me/certifications/{memberCertificationId}")
+    public ResponseEntity<ApiResponse<?>> deleteCertification(
+            @ProfileEntity Profile profile,
+            @Parameter(description = "삭제할 사용자 자격증 ID") @PathVariable Long memberCertificationId
+    ) {
+        memberCertificationService.deleteMemberCertification(profile, memberCertificationId);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.onSuccess(CertificationSuccessCode.CERTIFICATION_DELETED));
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/memberCertification/dto/request/MemberCertificationRequestDTO.java
+++ b/src/main/java/com/skala/nav7/api/certification/memberCertification/dto/request/MemberCertificationRequestDTO.java
@@ -1,0 +1,17 @@
+package com.skala.nav7.api.certification.memberCertification.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+public record MemberCertificationRequestDTO() {
+    public record CreateCertificationDTO(
+            @NotBlank(message = "자격증 아이디를 입력해주세요.")
+            @Schema(description = "자격증 아이디", example = "1")
+            Long certificationId,
+            @NotBlank(message = "자격증을 습득 년도를 입력해주세요. ")
+            @Schema(description = "자격증 습득 년도", example = "2022-05-01")
+            LocalDate acquisitionDate
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/memberCertification/dto/response/MemberCertificationResponseDTO.java
+++ b/src/main/java/com/skala/nav7/api/certification/memberCertification/dto/response/MemberCertificationResponseDTO.java
@@ -1,0 +1,18 @@
+package com.skala.nav7.api.certification.memberCertification.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Builder;
+
+public record MemberCertificationResponseDTO() {
+    @Builder
+    public record DefaultInfoDTO(
+            @Schema(description = "자격증 아이디", example = "1")
+            Long certificationId,
+            @Schema(description = "자격증 이름", example = "정보처리기사")
+            String certificationName,
+            @Schema(description = "경험 년도", example = "2022-05-01")
+            LocalDate acquisitionDate
+    ) {
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/memberCertification/entity/MemberCertification.java
+++ b/src/main/java/com/skala/nav7/api/certification/memberCertification/entity/MemberCertification.java
@@ -1,7 +1,7 @@
 package com.skala.nav7.api.certification.memberCertification.entity;
 
 import com.skala.nav7.api.certification.entity.Certification;
-import com.skala.nav7.api.member.entity.Member;
+import com.skala.nav7.api.profile.entity.Profile;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -34,8 +34,8 @@ public class MemberCertification {
     Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    Member member;
+    @JoinColumn(name = "profile_id", nullable = false)
+    Profile profile;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "certification_id", nullable = false)

--- a/src/main/java/com/skala/nav7/api/certification/memberCertification/repository/MemberCertificationRepository.java
+++ b/src/main/java/com/skala/nav7/api/certification/memberCertification/repository/MemberCertificationRepository.java
@@ -2,9 +2,13 @@ package com.skala.nav7.api.certification.memberCertification.repository;
 
 
 import com.skala.nav7.api.certification.memberCertification.entity.MemberCertification;
+import com.skala.nav7.api.profile.entity.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberCertificationRepository extends JpaRepository<MemberCertification, Long> {
+    Page<MemberCertification> findAllByProfile(Profile profile, Pageable pageable);
 }

--- a/src/main/java/com/skala/nav7/api/certification/repository/CertificationRepository.java
+++ b/src/main/java/com/skala/nav7/api/certification/repository/CertificationRepository.java
@@ -2,9 +2,13 @@ package com.skala.nav7.api.certification.repository;
 
 
 import com.skala.nav7.api.certification.entity.Certification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CertificationRepository extends JpaRepository<Certification, Long> {
+    boolean existsByCertificationName(String certificationName);
+
+    List<Certification> findByCertificationNameContainingIgnoreCase(String query);
 }

--- a/src/main/java/com/skala/nav7/api/certification/service/CertificationService.java
+++ b/src/main/java/com/skala/nav7/api/certification/service/CertificationService.java
@@ -1,0 +1,42 @@
+package com.skala.nav7.api.certification.service;
+
+import com.skala.nav7.api.certification.dto.response.CertificationResponseDTO.DefaultInfoDTO;
+import com.skala.nav7.api.certification.entity.Certification;
+import com.skala.nav7.api.certification.error.CertificationErrorCode;
+import com.skala.nav7.api.certification.error.CertificationException;
+import com.skala.nav7.api.certification.repository.CertificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CertificationService {
+    private final CertificationRepository certificationRepository;
+
+    public List<DefaultInfoDTO> searchCertifications(String query) {
+        List<Certification> certifications = certificationRepository.findByCertificationNameContainingIgnoreCase(query);
+        return certifications.stream()
+                .map(cert -> new DefaultInfoDTO(cert.getId(), cert.getCertificationName()))
+                .toList();
+    }
+
+    public DefaultInfoDTO createCertificationIfNotExists(String request) {
+        String input = request.trim();
+        if (certificationRepository.existsByCertificationName(input)) {
+            throw new CertificationException(CertificationErrorCode.ALREADY_EXIST_CERTIFICATION);
+        }
+
+        Certification saved = certificationRepository.save(
+                Certification.builder().certificationName(input).build()
+        );
+
+        return new DefaultInfoDTO(saved.getId(), saved.getCertificationName());
+    }
+
+    public Certification getCertification(Long certificationId) {
+        return certificationRepository.findById(certificationId).orElseThrow(
+                () -> new CertificationException(CertificationErrorCode.CERTIFICATION_NOT_FOUND)
+        );
+    }
+}

--- a/src/main/java/com/skala/nav7/api/certification/service/MemberCertificationService.java
+++ b/src/main/java/com/skala/nav7/api/certification/service/MemberCertificationService.java
@@ -1,0 +1,63 @@
+package com.skala.nav7.api.certification.service;
+
+import com.skala.nav7.api.certification.converter.CertificationConverter;
+import com.skala.nav7.api.certification.entity.Certification;
+import com.skala.nav7.api.certification.error.CertificationErrorCode;
+import com.skala.nav7.api.certification.error.CertificationException;
+import com.skala.nav7.api.certification.memberCertification.dto.request.MemberCertificationRequestDTO;
+import com.skala.nav7.api.certification.memberCertification.dto.response.MemberCertificationResponseDTO;
+import com.skala.nav7.api.certification.memberCertification.entity.MemberCertification;
+import com.skala.nav7.api.certification.memberCertification.repository.MemberCertificationRepository;
+import com.skala.nav7.api.profile.entity.Profile;
+import com.skala.nav7.global.apiPayload.pagenation.PageResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberCertificationService {
+    private final MemberCertificationRepository memberCertificationRepository;
+    private static final String ACQUISITION_DATE = "acquisitionDate";
+
+    public PageResponse<MemberCertificationResponseDTO.DefaultInfoDTO> getMemberCertifications(Profile profile,
+                                                                                               int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(ACQUISITION_DATE).ascending());
+        Page<MemberCertification> certifications = memberCertificationRepository.findAllByProfile(profile, pageRequest);
+        List<MemberCertificationResponseDTO.DefaultInfoDTO> contents = certifications.getContent().stream()
+                .map(CertificationConverter::to)
+                .toList();
+        return PageResponse.of(contents, certifications);
+    }
+
+    public void deleteMemberCertification(Profile profile, Long id) {
+        MemberCertification memberCertification = getMemberCertification(
+                id);
+        if (!memberCertification.getProfile().equals(profile)) {
+            throw new CertificationException(CertificationErrorCode.UNAUTHORIZED_CERTIFICATION_ACCESS);
+        }
+        memberCertificationRepository.delete(memberCertification);
+
+    }
+
+    private MemberCertification getMemberCertification(Long id) {
+        return memberCertificationRepository.findById(id).orElseThrow(
+                () -> new CertificationException(CertificationErrorCode.CERTIFICATION_NOT_FOUND)
+        );
+    }
+
+    public MemberCertification createNewMemberCertification(Profile profile,
+                                                            MemberCertificationRequestDTO.CreateCertificationDTO dto,
+                                                            Certification certification) {
+        MemberCertification memberCertification = MemberCertification.builder()
+                .certification(certification)
+                .acquisitionDate(dto.acquisitionDate())
+                .profile(profile)
+                .build();
+        return memberCertificationRepository.save(memberCertification);
+    }
+
+}

--- a/src/main/java/com/skala/nav7/api/experience/controller/ExperienceController.java
+++ b/src/main/java/com/skala/nav7/api/experience/controller/ExperienceController.java
@@ -4,6 +4,7 @@ import com.skala.nav7.api.experience.converter.ExperienceConverter;
 import com.skala.nav7.api.experience.dto.request.ExperienceRequestDTO;
 import com.skala.nav7.api.experience.dto.response.ExperienceResponseDTO;
 import com.skala.nav7.api.experience.entity.Experience;
+import com.skala.nav7.api.experience.error.ExperienceSuccessCode;
 import com.skala.nav7.api.experience.service.ExperienceService;
 import com.skala.nav7.api.profile.entity.Profile;
 import com.skala.nav7.global.apiPayload.ApiResponse;

--- a/src/main/java/com/skala/nav7/api/experience/error/ExperienceSuccessCode.java
+++ b/src/main/java/com/skala/nav7/api/experience/error/ExperienceSuccessCode.java
@@ -1,4 +1,4 @@
-package com.skala.nav7.api.experience.controller;
+package com.skala.nav7.api.experience.error;
 
 import com.skala.nav7.global.apiPayload.code.base.BaseCode;
 import com.skala.nav7.global.apiPayload.dto.ReasonDTO;


### PR DESCRIPTION
## 🔥 작업 개요
- 자격증(Certification) 마스터 테이블 및 사용자 자격증(MemberCertification) 연동 기능 구현
- DummyMemberInitializer에서 테스트용 자격증 데이터 초기화 추가
-
## ✅ 관련 이슈
- close #29 

## ✨ 주요 변경사항
- CertificationController: 자격증 마스터 등록 및 유사 자격증 자동 보정 생성 API 구현
- CertificationService: Levenshtein Distance 기반 유사도 계산 후 자격증 자동 연결 또는 새로 등록
- CertificationRepository: certificationName 기준 조회 및 존재 여부 확인 메서드 추가
- DummyMemberInitializer:
  - `initCertifications()` 메서드 추가 → 마스터 자격증 17종 초기 데이터 저장
  - `initMemberCertifications(Profile profile)` → Dummy 사용자의 자격증 9개 자동 연결

## 📸 스크린샷(선택)

## 🧪 테스트 (선택)
- [x] 로컬에서 테스트 완료
- [x] 테스트 코드 실행 (`./gradlew test`)

## 📝 ETC (선택)
